### PR TITLE
Don't require a remote kubeconfig

### DIFF
--- a/internal/kubernetes/config.go
+++ b/internal/kubernetes/config.go
@@ -92,8 +92,8 @@ func ParseConfigFile(path string) (ConfigFile, error) {
 
 // ValidateConfigFile returns an error if the supplied config is invalid.
 func ValidateConfigFile(cfg ConfigFile) error {
-	if cfg.Remote.KubeConfigPath == "" {
-		return errors.New("remote kubeconfig path is required")
+	if cfg.Remote.KubeConfigPath == "" && cfg.Local.KubeConfigPath == "" {
+		return errors.New("at least one of local or remote kubeconfig path is required")
 	}
 
 	for k, v := range cfg.Node.Resources.Allocatable {

--- a/internal/kubernetes/config_test.go
+++ b/internal/kubernetes/config_test.go
@@ -19,10 +19,10 @@ func TestValidateConfigFile(t *testing.T) {
 		cfg    ConfigFile
 		want   error
 	}{
-		"MissingRemoteKubecfgPath": {
-			reason: "A remote kubeconfig path is required",
+		"MissingBothKubecfgPaths": {
+			reason: "A remote or loca kubeconfig path is required to avoid both ends using in-cluster config",
 			cfg:    ConfigFile{},
-			want:   errors.New("remote kubeconfig path is required"),
+			want:   errors.New("at least one of local or remote kubeconfig path is required"),
 		},
 		"InvalidResourceValue": {
 			reason: "Resource values must be parseable",
@@ -57,6 +57,5 @@ func TestValidateConfigFile(t *testing.T) {
 				t.Errorf("\n%s\nValidateConfig(...): -want, +got: \n%s\n", tc.reason, diff)
 			}
 		})
-
 	}
 }


### PR DESCRIPTION
Instead, require that at least one kubeconfig file is provided. This allows AK to be deployed as a pod in either the local or the remote cluster, but ensures that both ends won't fall back to in-cluster config (i.e. that AK won't use the same cluster as local and remote).

CC @turkenh